### PR TITLE
Add new optimization rules to optimizations.md

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
@@ -347,6 +347,34 @@ module EVM-OPTIMIZATIONS
      andBool ( size( WS ) <=Int 1023 )
      [priority(40)]
 
+  rule
+    <kevm>
+      <k>
+        ( #next [ JUMPDEST ] => .K ) ...
+      </k>
+      <schedule>
+        SCHED
+      </schedule>
+      <ethereum>
+        <evm>
+          <callState>
+            <pc>
+              ( PCOUNT => ( PCOUNT +Int 1 ) )
+            </pc>
+            <gas>
+              ( GAVAIL => ( GAVAIL -Gas Gjumpdest < SCHED > ) )
+            </gas>
+            ...
+          </callState>
+          ...
+        </evm>
+        ...
+      </ethereum>
+      ...
+    </kevm>
+    requires ( Gjumpdest < SCHED > <=Gas GAVAIL )
+     [priority(40)]
+
 
 // {OPTIMIZATIONS}
 

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
@@ -371,7 +371,7 @@ module EVM-OPTIMIZATIONS
   rule
     <kevm>
       <k>
-        ( #next [ JUMP ] => .K ) ...
+        ( #next [ JUMP ] => #if W0 in DESTS #then .K #else #end EVMC_BAD_JUMP_DESTINATION #fi ) ...
       </k>
       <schedule>
         SCHED
@@ -400,13 +400,12 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Gmid < SCHED > <=Gas GAVAIL )
-     andBool W0 in DESTS
      [priority(40)]
 
   rule
     <kevm>
       <k>
-        ( #next [ JUMPI ] => .K ) ...
+        ( #next [ JUMPI ] => #if W0 in DESTS #then .K #else #end EVMC_BAD_JUMP_DESTINATION #fi ) ...
       </k>
       <schedule>
         SCHED
@@ -435,7 +434,6 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Ghigh < SCHED > <=Gas GAVAIL )
-     andBool W0 in DESTS
      [priority(40)]
 
 

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
@@ -152,7 +152,6 @@ module EVM-OPTIMIZATIONS
     </kevm>
     requires #stackNeeded(SWAP(N)) <=Int size(WS) +Int 1
      andBool ( Gverylow < SCHED > <=Gas GAVAIL )
-     andBool ( size( WS ) <=Int 1023 )
      [priority(40)]
 
   rule
@@ -184,7 +183,6 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Gverylow < SCHED > <=Gas GAVAIL )
-     andBool ( size( WS ) <=Int 1023 )
      [priority(40)]
 
   rule
@@ -216,7 +214,6 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Gverylow < SCHED > <=Gas GAVAIL )
-     andBool ( size( WS ) <=Int 1023 )
      [priority(40)]
 
   rule
@@ -248,7 +245,6 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Gverylow < SCHED > <=Gas GAVAIL )
-     andBool ( size( WS ) <=Int 1023 )
      [priority(40)]
 
   rule
@@ -280,7 +276,6 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Gverylow < SCHED > <=Gas GAVAIL )
-     andBool ( size( WS ) <=Int 1023 )
      [priority(40)]
 
   rule
@@ -312,7 +307,6 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Gverylow < SCHED > <=Gas GAVAIL )
-     andBool ( size( WS ) <=Int 1023 )
      [priority(40)]
 
   rule
@@ -344,7 +338,6 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Gverylow < SCHED > <=Gas GAVAIL )
-     andBool ( size( WS ) <=Int 1023 )
      [priority(40)]
 
   rule
@@ -407,7 +400,6 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Gmid < SCHED > <=Gas GAVAIL )
-     andBool ( size( WS ) <=Int 1023 )
      andBool W0 in DESTS
      [priority(40)]
 
@@ -443,7 +435,6 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Ghigh < SCHED > <=Gas GAVAIL )
-     andBool ( size( WS ) <=Int 1023 )
      andBool W0 in DESTS
      [priority(40)]
 

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
@@ -375,6 +375,42 @@ module EVM-OPTIMIZATIONS
     requires ( Gjumpdest < SCHED > <=Gas GAVAIL )
      [priority(40)]
 
+  rule
+    <kevm>
+      <k>
+        ( #next [ JUMP ] => .K ) ...
+      </k>
+      <schedule>
+        SCHED
+      </schedule>
+      <ethereum>
+        <evm>
+          <callState>
+            <jumpDests>
+              DESTS
+            </jumpDests>
+            <wordStack>
+              ( ListItem(W0) WS => WS )
+            </wordStack>
+            <pc>
+              ( PCOUNT => W0 )
+            </pc>
+            <gas>
+              ( GAVAIL => ( GAVAIL -Gas Gmid < SCHED > ) )
+            </gas>
+            ...
+          </callState>
+          ...
+        </evm>
+        ...
+      </ethereum>
+      ...
+    </kevm>
+    requires ( Gmid < SCHED > <=Gas GAVAIL )
+     andBool ( size( WS ) <=Int 1023 )
+     andBool W0 in DESTS
+     [priority(40)]
+
 
 // {OPTIMIZATIONS}
 

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
@@ -315,6 +315,38 @@ module EVM-OPTIMIZATIONS
      andBool ( size( WS ) <=Int 1023 )
      [priority(40)]
 
+  rule
+    <kevm>
+      <k>
+        ( #next [ ISZERO ] => .K ) ...
+      </k>
+      <schedule>
+        SCHED
+      </schedule>
+      <ethereum>
+        <evm>
+          <callState>
+            <wordStack>
+              ( ListItem(W0) WS => pushList(bool2Word( W0 ==Int 0 ), WS) )
+            </wordStack>
+            <pc>
+              ( PCOUNT => ( PCOUNT +Int 1 ) )
+            </pc>
+            <gas>
+              ( GAVAIL => ( GAVAIL -Gas Gverylow < SCHED > ) )
+            </gas>
+            ...
+          </callState>
+          ...
+        </evm>
+        ...
+      </ethereum>
+      ...
+    </kevm>
+    requires ( Gverylow < SCHED > <=Gas GAVAIL )
+     andBool ( size( WS ) <=Int 1023 )
+     [priority(40)]
+
 
 // {OPTIMIZATIONS}
 

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
@@ -411,6 +411,42 @@ module EVM-OPTIMIZATIONS
      andBool W0 in DESTS
      [priority(40)]
 
+  rule
+    <kevm>
+      <k>
+        ( #next [ JUMPI ] => .K ) ...
+      </k>
+      <schedule>
+        SCHED
+      </schedule>
+      <ethereum>
+        <evm>
+          <callState>
+            <jumpDests>
+              DESTS
+            </jumpDests>
+            <wordStack>
+              ( ListItem(W0) ListItem(W1) WS => WS )
+            </wordStack>
+            <pc>
+              ( PCOUNT => #if W1 =/=Int 0 #then W0 #else PCOUNT +Int 1 #fi )
+            </pc>
+            <gas>
+              ( GAVAIL => ( GAVAIL -Gas Ghigh < SCHED > ) )
+            </gas>
+            ...
+          </callState>
+          ...
+        </evm>
+        ...
+      </ethereum>
+      ...
+    </kevm>
+    requires ( Ghigh < SCHED > <=Gas GAVAIL )
+     andBool ( size( WS ) <=Int 1023 )
+     andBool W0 in DESTS
+     [priority(40)]
+
 
 // {OPTIMIZATIONS}
 

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
@@ -371,7 +371,7 @@ module EVM-OPTIMIZATIONS
   rule
     <kevm>
       <k>
-        ( #next [ JUMP ] => #if W0 in DESTS #then .K #else #end EVMC_BAD_JUMP_DESTINATION #fi ) ...
+        ( #next [ JUMP ] => .K ) ...
       </k>
       <schedule>
         SCHED
@@ -400,12 +400,13 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Gmid < SCHED > <=Gas GAVAIL )
+     andBool W0 in DESTS
      [priority(40)]
 
   rule
     <kevm>
       <k>
-        ( #next [ JUMPI ] => #if W0 in DESTS #then .K #else #end EVMC_BAD_JUMP_DESTINATION #fi ) ...
+        ( #next [ JUMPI ] => .K ) ...
       </k>
       <schedule>
         SCHED
@@ -434,6 +435,7 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Ghigh < SCHED > <=Gas GAVAIL )
+     andBool W0 in DESTS
      [priority(40)]
 
 


### PR DESCRIPTION
We measured which opcodes are most expensive. As a result of these measurements, we have identified 8 opcodes we want to try to add to optimizations.md. Four of them are included in this PR: ISZERO, JUMPDEST, JUMP, and JUMPI.