### PR TITLE
add support for branch for syncing master

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - 'master'
+  push:
+    branches:
+      - 'master-update'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
I am attempting to change how I maintain the history of our forks so that it will be easy to present clean, up-to-date diffs at any moment to the RV team, and also keep history clean and free from messy merges. As a result, I need a staging branch to exist that I can use to push code that I need to run CI on that will not become part of a pull request but will instead be force pushed to master when I rebase our diffs on top of the latest upstream master. This PR changes the triggers of the workflow slightly so it also triggers on pushes to the specifically named branch.