### PR TITLE
fix for latest version of code quality CI checks

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -14,15 +14,12 @@ jobs:
 
   kevm-pyk-code-quality-checks:
     name: 'Code Quality Checks'
-    runs-on: [self-hosted, linux, flyweight]
+    runs-on: ubuntu-latest
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-            python-version: "3.10"
       - name: 'Install Poetry'
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@v9
       - name: 'Run code quality checks'
         run: make -C kevm-pyk check
       - name: 'Run pyupgrade'
@@ -31,18 +28,12 @@ jobs:
   kevm-pyk-unit-tests:
     needs: kevm-pyk-code-quality-checks
     name: 'Unit Tests'
-    runs-on: [self-hosted, linux, normal]
+    runs-on: ubuntu-latest
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-            python-version: "3.10"
       - name: 'Install Poetry'
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@v9
       - name: 'Run unit tests'
         run: |
           make -C kevm-pyk cov-unit


### PR DESCRIPTION
The upstream repo changed how it did the code quality checks, and we need to update our own version of the CI files or it will no longer work correctly.