### PR TITLE
delete jumpDests cell

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -54,7 +54,6 @@ In the comments next to each cell, we've marked which component of the YellowPap
 
             <callState>
               <program>   .Bytes </program>
-              <jumpDests> .Bytes </jumpDests>
 
               // I_*
               <id>        .Account </id>                    // I_a
@@ -1066,8 +1065,8 @@ The `JUMP*` family of operations affect the current program counter.
  // ---------------------------
     rule <k> JUMP DEST => #endBasicBlock ... </k>
          <pc> _ => DEST </pc>
-         <jumpDests> DESTS </jumpDests>
-      requires DEST <Int lengthBytes(DESTS) andBool DESTS[DEST] ==Int 1
+         <program> DESTS </program>
+      requires DEST <Int lengthBytes(DESTS) andBool DESTS[DEST] ==Int 91
 
     rule <k> JUMP _ => #end EVMC_BAD_JUMP_DESTINATION ... </k> [owise]
 
@@ -1399,7 +1398,6 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
     rule [program.load]:
          <k> #loadProgram BYTES => .K ... </k>
          <program> _ => BYTES </program>
-         <jumpDests> _ => #computeValidJumpDests(BYTES) </jumpDests>
 
     syntax KItem ::= "#touchAccounts" Account | "#touchAccounts" Account Account
  // ----------------------------------------------------------------------------
@@ -1439,19 +1437,6 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
 
     rule <k> #accessAccounts ADDRSET:Set => .K ... </k>
          <accessedAccounts> TOUCHED_ACCOUNTS => TOUCHED_ACCOUNTS |Set ADDRSET </accessedAccounts>
-
-    syntax Bytes ::= #computeValidJumpDests(Bytes)             [symbol(computeValidJumpDests),    function, memo, total]
-                   | #computeValidJumpDests(Bytes, Int, Bytes) [symbol(computeValidJumpDestsAux), function             ]
- // --------------------------------------------------------------------------------------------------------------------
-    rule #computeValidJumpDests(PGM) => #computeValidJumpDests(PGM, 0, padRightBytes(.Bytes, lengthBytes(PGM), 0))
-
-    syntax Bytes ::= #computeValidJumpDestsWithinBound(Bytes, Int, Bytes) [symbol(computeValidJumpDestsWithinBound), function]
- // --------------------------------------------------------------------------------------------------------------------------
-    rule #computeValidJumpDests(PGM, I, RESULT) => RESULT requires I >=Int lengthBytes(PGM)
-    rule #computeValidJumpDests(PGM, I, RESULT) => #computeValidJumpDestsWithinBound(PGM, I, RESULT) requires I <Int lengthBytes(PGM)
-
-    rule #computeValidJumpDestsWithinBound(PGM, I, RESULT) => #computeValidJumpDests(PGM, I +Int 1, RESULT[I <- 1]) requires PGM [ I ] ==Int 91
-    rule #computeValidJumpDestsWithinBound(PGM, I, RESULT) => #computeValidJumpDests(PGM, I +Int #widthOpCode(PGM [ I ]), RESULT) requires notBool PGM [ I ] ==Int 91
 ```
 
 ```k

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/optimizations.md
@@ -375,9 +375,9 @@ module EVM-OPTIMIZATIONS
       <ethereum>
         <evm>
           <callState>
-            <jumpDests>
+            <program>
               DESTS
-            </jumpDests>
+            </program>
             <wordStack>
               ( ListItem(W0) WS => WS )
             </wordStack>
@@ -396,7 +396,7 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Gmid < SCHED > <=Gas GAVAIL )
-     andBool ( W0 <Int lengthBytes(DESTS) andBool DESTS[W0] ==Int 1 )
+     andBool ( W0 <Int lengthBytes(DESTS) andBool DESTS[W0] ==Int 91 )
      [priority(40)]
 
   rule
@@ -410,9 +410,9 @@ module EVM-OPTIMIZATIONS
       <ethereum>
         <evm>
           <callState>
-            <jumpDests>
+            <program>
               DESTS
-            </jumpDests>
+            </program>
             <wordStack>
               ( ListItem(W0) ListItem(W1) WS => WS )
             </wordStack>
@@ -431,7 +431,7 @@ module EVM-OPTIMIZATIONS
       ...
     </kevm>
     requires ( Ghigh < SCHED > <=Gas GAVAIL )
-     andBool ( W0 <Int lengthBytes(DESTS) andBool DESTS[W0] ==Int 1 )
+     andBool ( W0 <Int lengthBytes(DESTS) andBool DESTS[W0] ==Int 91 )
      [priority(40)]
 
 

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/state-utils.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/state-utils.md
@@ -33,7 +33,6 @@ module STATE-UTILS
          <callDepth>        _ => 0          </callDepth>
          <callStack>        _ => .List      </callStack>
          <program>          _ => .Bytes     </program>
-         <jumpDests>        _ => .Bytes     </jumpDests>
          <id>               _ => .Account   </id>
          <caller>           _ => .Account   </caller>
          <callData>         _ => .Bytes     </callData>


### PR DESCRIPTION
Computing the value of this cell is pretty much unnecessary because it is just computing a buffer that is equal in length to the assembly of the program but with 1s each place where a JUMPDEST opcode occurs. We can replace this with just on the fly checking whether the opcode at a particular index is a JUMPDEST opcode.