### PR TITLE
Fix `#codeDeposit` rule to set the output correctly when status is different from success

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -938,11 +938,7 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
     syntax KItem ::= "#codeDeposit" MessageResult
     rule <k> #codeDeposit(MessageResult(... gas: GAVAIL, status: STATUS, data:OUT)) => #refund GAVAIL ~> 0 ~> #push ...</k>
          <output> _ => OUT </output>
-      requires STATUS ==Int EVMC_REVERT
-
-    rule <k> #codeDeposit(MessageResult(... status: STATUS)) => 0 ~> #push ...</k>
-        <output> _ => .Bytes </output>
-      requires STATUS =/=Int EVMC_SUCCESS andBool STATUS =/=Int EVMC_REVERT
+      requires STATUS =/=Int EVMC_SUCCESS
 
     rule <k> #codeDeposit(MessageResult(... gas: GAVAIL, status: STATUS, target: ACCT)) => #refund GAVAIL ~> ACCT ~> #push ...</k>
          <output> _ => .Bytes </output>

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -938,7 +938,11 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
     syntax KItem ::= "#codeDeposit" MessageResult
     rule <k> #codeDeposit(MessageResult(... gas: GAVAIL, status: STATUS, data:OUT)) => #refund GAVAIL ~> 0 ~> #push ...</k>
          <output> _ => OUT </output>
-      requires STATUS =/=Int EVMC_SUCCESS
+      requires STATUS ==Int EVMC_REVERT
+
+    rule <k> #codeDeposit(MessageResult(... gas: GAVAIL, status: STATUS)) => #refund GAVAIL ~> 0 ~> #push ...</k>
+        <output> _ => .Bytes </output>
+      requires STATUS =/=Int EVMC_SUCCESS andBool STATUS =/=Int EVMC_REVERT
 
     rule <k> #codeDeposit(MessageResult(... gas: GAVAIL, status: STATUS, target: ACCT)) => #refund GAVAIL ~> ACCT ~> #push ...</k>
          <output> _ => .Bytes </output>

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -940,7 +940,7 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
          <output> _ => OUT </output>
       requires STATUS ==Int EVMC_REVERT
 
-    rule <k> #codeDeposit(MessageResult(... gas: GAVAIL, status: STATUS)) => #refund GAVAIL ~> 0 ~> #push ...</k>
+    rule <k> #codeDeposit(MessageResult(... status: STATUS)) => 0 ~> #push ...</k>
         <output> _ => .Bytes </output>
       requires STATUS =/=Int EVMC_SUCCESS andBool STATUS =/=Int EVMC_REVERT
 

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -936,7 +936,8 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
     rule #hasValidInitCode(INITCODELEN, SCHED) => notBool Ghasmaxinitcodesize << SCHED >> orBool INITCODELEN <=Int maxInitCodeSize < SCHED >
 
     syntax KItem ::= "#codeDeposit" MessageResult
-    rule <k> #codeDeposit(MessageResult(... gas: GAVAIL, status: STATUS)) => #refund GAVAIL ~> 0 ~> #push ...</k>
+    rule <k> #codeDeposit(MessageResult(... gas: GAVAIL, status: STATUS, data:OUT)) => #refund GAVAIL ~> 0 ~> #push ...</k>
+         <output> _ => OUT </output>
       requires STATUS =/=Int EVMC_SUCCESS
 
     rule <k> #codeDeposit(MessageResult(... gas: GAVAIL, status: STATUS, target: ACCT)) => #refund GAVAIL ~> ACCT ~> #push ...</k>


### PR DESCRIPTION
This PR fixes a behavior where we didn't persist the output from the execution of the `revert` opcode. Without this issue, tests that rely on the result of this operation were failing with gas mismatch, i.e., operations that were supposed to happen didn't execute. This PR addresses the issue and doesn't add any regression to the test suite.