### PR TITLE
the direct build of the target `libkevm/libkevm.so`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ CXX               := clang++-16
 $(VLM_KLLVM_LIB):
 	$(MAKE) -C $(VLM_KLLVM_DIR) CPPFLAGS=-DEVM_ONLY
 
-$(CRYPTO_PLUGIN_LIB): init-submodules
+$(CRYPTO_PLUGIN_LIB):
 	$(MAKE) -C $(CRYPTO_PLUGIN_DIR)
 
 $(KEVM_TARGET_LIB): $(VLM_KLLVM_LIB) $(EVM_K_SOURCES) $(CRYPTO_PLUGIN_LIB)
@@ -260,7 +260,7 @@ init-submodules:
 	cd $(CRYPTO_PLUGIN_DIR) && git submodule update --init --recursive
 
 .PHONY: evm-semantics
-evm-semantics: init-submodules $(KEVM_TARGET_LIB)
+evm-semantics: $(KEVM_TARGET_LIB)
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ poetry -C kevm-pyk run kdist clean
 
 For more information, refer to `kdist --help` and the [dist.py](kevm-pyk/src/kevm_pyk/dist.py) module.
 
+#### Easy `Makefile` build.
+
+Run `make evm-semantics` for direct build of the target `libkevm/libkevm.so` library. As a dependency, the `lib/krypto.a` will be also build.
+Run `make clean` to clean up the results of `make evm-semantics` command.
+
 Running Tests
 -------------
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,13 @@ For more information, refer to `kdist --help` and the [dist.py](kevm-pyk/src/kev
 
 #### Easy `Makefile` build.
 
-Run `make evm-semantics` for direct build of the target `libkevm/libkevm.so` library. As a dependency, the `lib/krypto.a` will be also build.
+To ensure all submodules are update, use
+
+```sh
+make init-submodules
+```
+
+Run `make` or `make evm-semantics` for direct build of the target `libkevm/libkevm.so` library. As a dependency, the `lib/krypto.a` will be also build.
 Run `make clean` to clean up the results of `make evm-semantics` command.
 
 Running Tests


### PR DESCRIPTION
The `Makefile` is updated so that `libkevm/libkevm.so` may be build directly, without pyhton scripts.

**Note:**
I added the Makefile command to make the `libulmkllvm` library:
```make
libulmkllvm:
	$(MAKE) -C $(VLM_KLLVM_DIR) -j$(shell nproc)
```
which is _outside_ of `evm-semantics` library (it's in the `vlm` repository), but which is needed as a dependency.