### PR TITLE
Update `schedule.md` to return `PRAGUE` in `getSchedule`

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
@@ -34,6 +34,7 @@ module SCHEDULE
     rule getSchedule(10) => MERGE
     rule getSchedule(11) => SHANGHAI
     rule getSchedule(12) => CANCUN
+    rule getSchedule(13) => PRAGUE
 
     syntax Bool ::= ScheduleFlag "<<" Schedule ">>" [function, total]
  // -----------------------------------------------------------------


### PR DESCRIPTION
We forgot to modify the `getSchedule` function to return `PRAGUE` once given the number `13` when we added the new schedule to the semantics. This small PR fixes this issue.