### PR TITLE
Replacing the RHS of `EXTCODEHASH` to use its own hook

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -761,7 +761,7 @@ Operators that require access to the rest of the Ethereum network world-state ca
 
     syntax UnStackOp ::= "EXTCODEHASH"
  // ----------------------------------
-    rule <k> EXTCODEHASH ACCT => keccak(GetAccountCode(ACCT)) ~> #push ... </k>
+    rule <k> EXTCODEHASH ACCT => GetCodeHash(ACCT) ~> #push ... </k>
       requires notBool IsAccountEmpty(ACCT)
 
     rule <k> EXTCODEHASH ACCT => AccessAccount(ACCT) ~> 0 ~> #push ... </k> [owise]


### PR DESCRIPTION
This PR is necessary to fix the implementation of the `EXTCODEHASH` opcode that was returning the wrong value. This will also be useful for implementing EIP-7702, as this EIP modifies the implementation of this opcode.

This is the last PR of three PRs needed to implement this feature fully. The [first](https://github.com/Pi-Squared-Inc/op-geth/pull/8) PR that should be reviewed and merged is in the op-geth repo, then the [second](https://github.com/Pi-Squared-Inc/vlm/pull/351) PR in the VLM repo should be reviewed and merged, so the current PR can finally have the modifications needed to make the new `GetCodeHash` function work.