### PR TITLE
`EVMC_PRECOMPILE_OOG` error type

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -1263,6 +1263,11 @@ Precompiled Contracts
     rule #precompiled(16p256) => BLS12MAPFPTOG1
     rule #precompiled(17p256) => BLS12MAPFP2TOG2
 
+    syntax Bool ::= isPrecompiledOP(OpCode) [function]
+ // --------------------------------------------------
+    rule isPrecompiledOP(_:PrecompiledOp) => true
+    rule isPrecompiledOP(_) => false [owise]
+
     syntax MInt{256} ::= #precompiledAccountsUB ( Schedule ) [symbol(#precompiledAccountsUB), function, total]
  // ----------------------------------------------------------------------------------------------------
     rule #precompiledAccountsUB(FRONTIER)          => 4p256
@@ -1827,7 +1832,7 @@ Overall Gas
          <memoryUsed> MU => MU' </memoryUsed> <schedule> SCHED </schedule>
 
     rule <k> _G:Gas ~> (#deductMemoryGas => #deductGas)   ... </k> //Required for verification
-    rule <k>  G:Gas ~> #deductGas => #end EVMC_OUT_OF_GAS ... </k> <gas> GAVAIL                  </gas> requires GAVAIL <Gas G
+    rule <k>  G:Gas ~> #deductGas ~> #access [ _, _, _ ] ~> OP  => #end #if isOptimismSchedule(SCHED) andBool isPrecompiledOP(OP) #then EVMC_PRECOMPILE_OOG #else EVMC_OUT_OF_GAS #fi ... </k> <gas> GAVAIL                  </gas> <schedule> SCHED </schedule>requires GAVAIL <Gas G
     rule <k>  G:Gas ~> #deductGas => .K                   ... </k> <gas> GAVAIL => GAVAIL -Gas G </gas> requires G <=Gas GAVAIL
 
     syntax Bool ::= #inStorage     ( Map   , Account , Int ) [symbol(#inStorage), function, total]

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -115,6 +115,7 @@ Output Extraction
     rule getStatus(EVMC_STATIC_MODE_VIOLATION) => EVMC_STATIC_MODE_VIOLATION
     rule getStatus(EVMC_PRECOMPILE_FAILURE) => EVMC_PRECOMPILE_FAILURE
     rule getStatus(EVMC_NONCE_EXCEEDED) => EVMC_NONCE_EXCEEDED
+    rule getStatus(EVMC_PRECOMPILE_OOG) => EVMC_PRECOMPILE_OOG
 
     rule getGasLeft(G) => 0 requires getStatus(G) =/=Int EVMC_SUCCESS andBool getStatus(G) =/=Int EVMC_REVERT
     rule getGasLeft(<generatedTop>... <gas> G </gas> ...</generatedTop>) => G [priority(51)]

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/network.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/network.md
@@ -32,6 +32,7 @@ The following codes all indicate that the VM ended execution with an exception, 
 -   `EVMC_STATIC_MODE_VIOLATION` indicates that a `STATICCALL` tried to change state.
     **TODO:** Avoid `_ERROR` suffix that suggests fatal error.
 -   `EVMC_PRECOMPILE_FAILURE` indicates an errors in the precompiled contracts (eg. invalid points handed to elliptic curve functions).
+-   `EVMC_PRECOMPILE_OOG` indicates that the gas supply was exhausted during the execution of a precompiled contract.
 
 ```k
     syntax ExceptionalStatusCode ::= "EVMC_FAILURE"
@@ -46,6 +47,7 @@ The following codes all indicate that the VM ended execution with an exception, 
                                    | "EVMC_STATIC_MODE_VIOLATION"
                                    | "EVMC_PRECOMPILE_FAILURE"
                                    | "EVMC_NONCE_EXCEEDED"
+                                   | "EVMC_PRECOMPILE_OOG"
  // -------------------------------------------------------------
     rule StatusCode2String(EVMC_FAILURE)               => "EVMC_FAILURE"
     rule StatusCode2String(EVMC_INVALID_INSTRUCTION)   => "EVMC_INVALID_INSTRUCTION"
@@ -59,6 +61,7 @@ The following codes all indicate that the VM ended execution with an exception, 
     rule StatusCode2String(EVMC_STATIC_MODE_VIOLATION) => "EVMC_STATIC_MODE_VIOLATION"
     rule StatusCode2String(EVMC_PRECOMPILE_FAILURE)    => "EVMC_PRECOMPILE_FAILURE"
     rule StatusCode2String(EVMC_NONCE_EXCEEDED)        => "EVMC_NONCE_EXCEEDED"
+    rule StatusCode2String(EVMC_PRECOMPILE_OOG)        => "EVMC_PRECOMPILE_OOG"
 ```
 
 ### Ending Codes

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
@@ -44,6 +44,31 @@ module SCHEDULE
     rule getSchedule(106) => HOLOCENE
     rule getSchedule(107) => ISTHMUS
 
+    syntax Bool ::= isOptimismSchedule(Schedule) [function]
+ // -------------------------------------------------------
+    rule isOptimismSchedule(BEDROCK) => true
+    rule isOptimismSchedule(REGOLITH) => true
+    rule isOptimismSchedule(CANYON) => true
+    rule isOptimismSchedule(ECOTONE) => true
+    rule isOptimismSchedule(FJORD) => true
+    rule isOptimismSchedule(GRANITE) => true
+    rule isOptimismSchedule(HOLOCENE) => true
+    rule isOptimismSchedule(ISTHMUS) => true
+    rule isOptimismSchedule(FRONTIER) => false
+    rule isOptimismSchedule(HOMESTEAD) => false
+    rule isOptimismSchedule(TANGERINE_WHISTLE) => false
+    rule isOptimismSchedule(SPURIOUS_DRAGON) => false
+    rule isOptimismSchedule(BYZANTIUM) => false
+    rule isOptimismSchedule(CONSTANTINOPLE) => false
+    rule isOptimismSchedule(PETERSBURG) => false
+    rule isOptimismSchedule(ISTANBUL) => false
+    rule isOptimismSchedule(BERLIN) => false
+    rule isOptimismSchedule(LONDON) => false
+    rule isOptimismSchedule(MERGE) => false
+    rule isOptimismSchedule(SHANGHAI) => false
+    rule isOptimismSchedule(CANCUN) => false
+    rule isOptimismSchedule(PRAGUE) => false
+
     syntax Bool ::= ScheduleFlag "<<" Schedule ">>" [function, total]
  // -----------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds the `EVMC_PRECOMPILE_OOG` error type, which is needed for op-revm, and returns is when appropriate (out of gas when executing a precompiled contract with an optimism schedule).

To return the correct error, `EVMC_PRECOMPILE_OOG` or `EVMC_Out_Of_Gas`, we need to know whether a particular OOG is during execution of a precompiled contract -  to that end, we added a cell that contains this information.

The remaining 2 op-revm unit tests that are failing will be investigated as part of new PRs.