### PR TITLE
Input validation for ECPAIRING in GRANITE.

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -235,9 +235,8 @@ The `#next [_]` operator initiates execution by:
 
 1.  checking if there will be a stack over/underflow, or a static mode violation,
 2.  calculate any address conversions needed for items on the wordstack,
-3.  perform input checks as needed for certain precompiled contracts,
-4.  executing the opcode (which includes any gas deduction needed), and
-5.  adjusting the program counter.
+3.  executing the opcode (which includes any gas deduction needed), and
+4.  adjusting the program counter.
 
 ```k
     syntax InternalOp ::= "#next" "[" MaybeOpCode "]"
@@ -247,7 +246,6 @@ The `#next [_]` operator initiates execution by:
 
     rule <k> #next [ OP:OpCode ]
           => #addr [ OP ]
-          ~> #validateInput [ OP ]
           ~> #exec [ OP ]
           ~> #pc   [ OP ]
          ...
@@ -428,25 +426,6 @@ We make sure the given arguments (to be interpreted as addresses) are with 160 b
     rule isAddr2Op(_:CallOp)    => true
     rule isAddr2Op(_:CallSixOp) => true
     rule isAddr2Op(_)           => false [owise]
-
-    syntax KItem ::= "#validateInput" "[" OpCode "]" [symbol(validateInput)]
- // ------------------------------------------------------------------------
-    rule <k> #validateInput [ ECPAIRING ] => #end EVMC_PRECOMPILE_FAILURE ... </k>
-         <callData> CD </callData>
-         <schedule> SCHED </schedule>
-      requires hasInputValidation(ECPAIRING, SCHED) andBool lengthBytes(CD) >Int graniteMaxInputSize
-    rule <k> #validateInput [ ECPAIRING ] => .K ... </k>
-         <callData> CD </callData>
-         <schedule> SCHED </schedule>
-      requires notBool hasInputValidation(ECPAIRING, SCHED) orBool lengthBytes(CD) <=Int graniteMaxInputSize
-    rule <k> #validateInput [ _ ] => .K ... </k> [owise]
-
-    syntax Bool ::= hasInputValidation ( OpCode , Schedule ) [symbol(hasInputValidation), function, total]
- // ------------------------------------------------------------------------------------------------------
-    rule hasInputValidation(ECPAIRING, GRANITE ) => true
-    rule hasInputValidation(ECPAIRING, HOLOCENE) => true
-    rule hasInputValidation(ECPAIRING, ISTHMUS ) => true
-    rule hasInputValidation(        _,       _ ) => false [owise]
 ```
 
 ### Program Counter
@@ -2153,7 +2132,7 @@ The intrinsic gas calculation mirrors the style of the YellowPaper (appendix H).
 
     rule <k> #gasExec(SCHED, ECADD)     => Gecadd < SCHED>  ... </k>
     rule <k> #gasExec(SCHED, ECMUL)     => Gecmul < SCHED > ... </k>
-   rule <k> #gasExec(SCHED, ECPAIRING) => Gecpairconst < SCHED > +Int (lengthBytes(CD) /Int 192) *Int Gecpaircoeff < SCHED > ... </k> <callData> CD </callData>
+   rule <k> #gasExec(SCHED, ECPAIRING) => #if (SCHED ==K GRANITE orBool SCHED ==K HOLOCENE orBool SCHED ==K ISTHMUS) andBool lengthBytes(CD) >Int graniteMaxInputSize #then #end EVMC_PRECOMPILE_FAILURE #else Gecpairconst < SCHED > +Int (lengthBytes(CD) /Int 192) *Int Gecpaircoeff < SCHED > #fi ... </k> <callData> CD </callData>
 
     rule <k> #gasExec(SCHED, BLAKE2F)   => Gfround < SCHED > *Int #asWord(#range(CD, 0, 4) ) ... </k> <callData> CD </callData>
     rule <k> #gasExec(SCHED, KZGPOINTEVAL)  => Gpointeval < SCHED > ... </k>

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -439,9 +439,7 @@ We make sure the given arguments (to be interpreted as addresses) are with 160 b
          <callData> CD </callData>
          <schedule> SCHED </schedule>
       requires notBool hasInputValidation(ECPAIRING, SCHED) orBool lengthBytes(CD) <=Int graniteMaxInputSize
-    rule <k> #validateInput [ OP:OpCode ] => .K ... </k>
-         <schedule> SCHED </schedule>
-      requires notBool hasInputValidation(OP, SCHED)
+    rule <k> #validateInput [ _ ] => .K ... </k> [owise]
 
     syntax Bool ::= hasInputValidation ( OpCode , Schedule ) [symbol(hasInputValidation), function, total]
  // ------------------------------------------------------------------------------------------------------

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -2132,7 +2132,7 @@ The intrinsic gas calculation mirrors the style of the YellowPaper (appendix H).
 
     rule <k> #gasExec(SCHED, ECADD)     => Gecadd < SCHED>  ... </k>
     rule <k> #gasExec(SCHED, ECMUL)     => Gecmul < SCHED > ... </k>
-   rule <k> #gasExec(SCHED, ECPAIRING) => #if (SCHED ==K GRANITE orBool SCHED ==K HOLOCENE orBool SCHED ==K ISTHMUS) andBool lengthBytes(CD) >Int graniteMaxInputSize #then #end EVMC_PRECOMPILE_FAILURE #else Gecpairconst < SCHED > +Int (lengthBytes(CD) /Int 192) *Int Gecpaircoeff < SCHED > #fi ... </k> <callData> CD </callData>
+   rule <k> #gasExec(SCHED, ECPAIRING) => #if Gecpairinputcheck << SCHED >> andBool lengthBytes(CD) >Int graniteMaxInputSize #then #end EVMC_PRECOMPILE_FAILURE #else Gecpairconst < SCHED > +Int (lengthBytes(CD) /Int 192) *Int Gecpaircoeff < SCHED > #fi ... </k> <callData> CD </callData>
 
     rule <k> #gasExec(SCHED, BLAKE2F)   => Gfround < SCHED > *Int #asWord(#range(CD, 0, 4) ) ... </k> <callData> CD </callData>
     rule <k> #gasExec(SCHED, KZGPOINTEVAL)  => Gpointeval < SCHED > ... </k>

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
@@ -79,7 +79,7 @@ module SCHEDULE
                           | "Ghasrejectedfirstbyte"   | "Ghasprevrandao"   | "Ghasmaxinitcodesize" | "Ghaspushzero"
                           | "Ghaswarmcoinbase"        | "Ghaswithdrawals"  | "Ghastransient"       | "Ghasmcopy"
                           | "Ghasbeaconroot"          | "Ghaseip6780"      | "Ghasblobbasefee"     | "Ghasblobhash"
-                          | "Ghasbls12msmdiscount"    | "Ghasdelegation"
+                          | "Ghasbls12msmdiscount"    | "Ghasdelegation"   | "Gecpairinputcheck"
 ```
 
 ### Schedule Constants
@@ -218,6 +218,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << FRONTIER >> => false
     rule Ghasbls12msmdiscount    << FRONTIER >> => false
     rule Ghasdelegation          << FRONTIER >> => false
+    rule Gecpairinputcheck       << FRONTIER >> => false
 ```
 
 ### Homestead Schedule
@@ -335,6 +336,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << HOMESTEAD >> => false
     rule Ghasbls12msmdiscount    << HOMESTEAD >> => false
     rule Ghasdelegation          << HOMESTEAD >> => false
+    rule Gecpairinputcheck       << HOMESTEAD >> => false
 ```
 
 ### Tangerine Whistle Schedule
@@ -452,6 +454,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << TANGERINE_WHISTLE >> => false
     rule Ghasbls12msmdiscount    << TANGERINE_WHISTLE >> => false
     rule Ghasdelegation          << TANGERINE_WHISTLE >> => false
+    rule Gecpairinputcheck       << TANGERINE_WHISTLE >> => false
 ```
 
 ### Spurious Dragon Schedule
@@ -569,6 +572,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << SPURIOUS_DRAGON >> => false
     rule Ghasbls12msmdiscount    << SPURIOUS_DRAGON >> => false
     rule Ghasdelegation          << SPURIOUS_DRAGON >> => false
+    rule Gecpairinputcheck       << SPURIOUS_DRAGON >> => false
 ```
 
 ### Byzantium Schedule
@@ -686,6 +690,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << BYZANTIUM >> => false
     rule Ghasbls12msmdiscount    << BYZANTIUM >> => false
     rule Ghasdelegation          << BYZANTIUM >> => false
+    rule Gecpairinputcheck       << BYZANTIUM >> => false
 ```
 
 ### Constantinople Schedule
@@ -803,6 +808,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << CONSTANTINOPLE >> => false
     rule Ghasbls12msmdiscount    << CONSTANTINOPLE >> => false
     rule Ghasdelegation          << CONSTANTINOPLE >> => false
+    rule Gecpairinputcheck       << CONSTANTINOPLE >> => false
 ```
 
 ### Petersburg Schedule
@@ -920,6 +926,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << PETERSBURG >> => false
     rule Ghasbls12msmdiscount    << PETERSBURG >> => false
     rule Ghasdelegation          << PETERSBURG >> => false
+    rule Gecpairinputcheck       << PETERSBURG >> => false
 ```
 
 ### Istanbul Schedule
@@ -1037,6 +1044,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << ISTANBUL >> => false
     rule Ghasbls12msmdiscount    << ISTANBUL >> => false
     rule Ghasdelegation          << ISTANBUL >> => false
+    rule Gecpairinputcheck       << ISTANBUL >> => false
 ```
 
 ### Berlin Schedule
@@ -1154,6 +1162,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << BERLIN >> => false
     rule Ghasbls12msmdiscount    << BERLIN >> => false
     rule Ghasdelegation          << BERLIN >> => false
+    rule Gecpairinputcheck       << BERLIN >> => false
 ```
 
 ### London Schedule
@@ -1271,6 +1280,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << LONDON >> => false
     rule Ghasbls12msmdiscount    << LONDON >> => false
     rule Ghasdelegation          << LONDON >> => false
+    rule Gecpairinputcheck       << LONDON >> => false
 ```
 
 ### Merge Schedule
@@ -1388,6 +1398,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << MERGE >> => false
     rule Ghasbls12msmdiscount    << MERGE >> => false
     rule Ghasdelegation          << MERGE >> => false
+    rule Gecpairinputcheck       << MERGE >> => false
 ```
 
 ### Shanghai Schedule
@@ -1506,6 +1517,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << SHANGHAI >> => false
     rule Ghasbls12msmdiscount    << SHANGHAI >> => false
     rule Ghasdelegation          << SHANGHAI >> => false
+    rule Gecpairinputcheck       << SHANGHAI >> => false
 ```
 
 ### Cancun Schedule
@@ -1624,6 +1636,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << CANCUN >> => true
     rule Ghasbls12msmdiscount    << CANCUN >> => false
     rule Ghasdelegation          << CANCUN >> => false
+    rule Gecpairinputcheck       << CANCUN >> => false
 ```
 
 ### Prague Schedule
@@ -1743,6 +1756,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << PRAGUE >> => true
     rule Ghasbls12msmdiscount    << PRAGUE >> => true
     rule Ghasdelegation          << PRAGUE >> => true
+    rule Gecpairinputcheck       << PRAGUE >> => false
 ```
 
 ### Bedrock Schedule
@@ -1860,6 +1874,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << BEDROCK >> => false
     rule Ghasbls12msmdiscount    << BEDROCK >> => false
     rule Ghasdelegation          << BEDROCK >> => false
+    rule Gecpairinputcheck       << BEDROCK >> => false
 ```
 
 ### Regolith Schedule
@@ -1977,6 +1992,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << REGOLITH >> => false
     rule Ghasbls12msmdiscount    << REGOLITH >> => false
     rule Ghasdelegation          << REGOLITH >> => false
+    rule Gecpairinputcheck       << REGOLITH >> => false
 ```
 
 ### Canyon Schedule
@@ -2095,6 +2111,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << CANYON >> => false
     rule Ghasbls12msmdiscount    << CANYON >> => false
     rule Ghasdelegation          << CANYON >> => false
+    rule Gecpairinputcheck       << CANYON >> => false
 ```
 
 ### Ecotone Schedule
@@ -2213,6 +2230,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << ECOTONE >> => true
     rule Ghasbls12msmdiscount    << ECOTONE >> => false
     rule Ghasdelegation          << ECOTONE >> => false
+    rule Gecpairinputcheck       << ECOTONE >> => false
 ```
 
 ### Fjord Schedule
@@ -2331,6 +2349,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << FJORD >> => true
     rule Ghasbls12msmdiscount    << FJORD >> => false
     rule Ghasdelegation          << FJORD >> => false
+    rule Gecpairinputcheck       << FJORD >> => false
 ```
 
 ### Granite Schedule
@@ -2449,6 +2468,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << GRANITE >> => true
     rule Ghasbls12msmdiscount    << GRANITE >> => false
     rule Ghasdelegation          << GRANITE >> => false
+    rule Gecpairinputcheck       << GRANITE >> => true
 ```
 
 ### Holocene Schedule
@@ -2567,6 +2587,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << HOLOCENE >> => true
     rule Ghasbls12msmdiscount    << HOLOCENE >> => false
     rule Ghasdelegation          << HOLOCENE >> => false
+    rule Gecpairinputcheck       << HOLOCENE >> => true
 ```
 
 ### Isthmus Schedule
@@ -2686,6 +2707,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasblobhash            << ISTHMUS >> => true
     rule Ghasbls12msmdiscount    << ISTHMUS >> => true
     rule Ghasdelegation          << ISTHMUS >> => true
+    rule Gecpairinputcheck       << ISTHMUS >> => true
 
 endmodule
 ```

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/word.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/word.md
@@ -470,6 +470,10 @@ The maximum and minimum values of each type are defined below.
     syntax Int ::= "blsModulus" [macro]
  // -----------------------------------
     rule blsModulus => 52435875175126190479447740508185965837690552500527637822603658699938581184513
+
+    syntax Int ::= "graniteMaxInputSize" [macro]
+ // -----------------------------------
+    rule graniteMaxInputSize => 112687
 ```
 
 Range of types


### PR DESCRIPTION
This PR adds the input validation `inputLength <= GRANITE_MAX_INPUT_SIZE` needed for precompile `ECPAIRING`.

As discussed, I implemented the input validation by adding a separate KItem before gas calculation, so that there is a designated place for input validation, which is needed for more of the optimism precompiles in other protocol versions as well.

Related issue: Pi-Squared-Inc/pi2/issues/2812