### PR TITLE
Allow for random/non consecutive precompile addresses.

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -954,10 +954,6 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
     rule [precompile.true]:  <k> #precompiled?(ACCTCODE, SCHED) => #next [ #precompiled(ACCTCODE) ] ... </k> <isPrecompile> _ => true </isPrecompile> requires         #isPrecompiledAccount(ACCTCODE, SCHED) [preserves-definedness]
     rule [precompile.false]: <k> #precompiled?(ACCTCODE, SCHED) => .K                               ... </k> requires notBool #isPrecompiledAccount(ACCTCODE, SCHED)
 
-    syntax Bool ::= #isPrecompiledAccount ( MInt{256} , Schedule ) [symbol(isPrecompiledAccount), function, total, smtlib(isPrecompiledAccount)]
- // --------------------------------------------------------------------------------------------------------------------------------------
-    rule [isPrecompiledAccount]:  #isPrecompiledAccount(ACCTCODE, SCHED) => 0p256 <uMInt ACCTCODE andBool ACCTCODE <=uMInt #precompiledAccountsUB(SCHED)
-
     syntax KItem ::= "#initVM"
  // --------------------------
     rule <k> #initVM      => .K ... </k>
@@ -1242,8 +1238,6 @@ Precompiled Contracts
 ---------------------
 
 -   `#precompiled` is a placeholder for the pre-compiled contracts of a given schedule. These contracts are located at contiguous addresses starting from 1.
--   `#precompiledAccountsUB`  returns the highest address (upper bound) of the precompiled contract accounts
--   `#precompiledAccountsSet` returns the set of addresses of the precompiled contract accounts
 
 ```k
     syntax NullStackOp   ::= PrecompiledOp
@@ -1266,40 +1260,6 @@ Precompiled Contracts
     rule #precompiled(15p256) => BLS12PAIRING_CHECK
     rule #precompiled(16p256) => BLS12MAPFPTOG1
     rule #precompiled(17p256) => BLS12MAPFP2TOG2
-
-    syntax MInt{256} ::= #precompiledAccountsUB ( Schedule ) [symbol(#precompiledAccountsUB), function, total]
- // ----------------------------------------------------------------------------------------------------
-    rule #precompiledAccountsUB(FRONTIER)          => 4p256
-    rule #precompiledAccountsUB(HOMESTEAD)         => #precompiledAccountsUB(FRONTIER)
-    rule #precompiledAccountsUB(TANGERINE_WHISTLE) => #precompiledAccountsUB(HOMESTEAD)
-    rule #precompiledAccountsUB(SPURIOUS_DRAGON)   => #precompiledAccountsUB(TANGERINE_WHISTLE)
-    rule #precompiledAccountsUB(BYZANTIUM)         => 8p256
-    rule #precompiledAccountsUB(CONSTANTINOPLE)    => #precompiledAccountsUB(BYZANTIUM)
-    rule #precompiledAccountsUB(PETERSBURG)        => #precompiledAccountsUB(CONSTANTINOPLE)
-    rule #precompiledAccountsUB(ISTANBUL)          => 9p256
-    rule #precompiledAccountsUB(BERLIN)            => #precompiledAccountsUB(ISTANBUL)
-    rule #precompiledAccountsUB(LONDON)            => #precompiledAccountsUB(BERLIN)
-    rule #precompiledAccountsUB(MERGE)             => #precompiledAccountsUB(LONDON)
-    rule #precompiledAccountsUB(SHANGHAI)          => #precompiledAccountsUB(MERGE)
-    rule #precompiledAccountsUB(CANCUN)            => 10p256
-    rule #precompiledAccountsUB(PRAGUE)            => 17p256
-    rule #precompiledAccountsUB(BEDROCK)           => #precompiledAccountsUB(MERGE)
-    rule #precompiledAccountsUB(REGOLITH)          => #precompiledAccountsUB(BEDROCK)
-    rule #precompiledAccountsUB(CANYON)            => #precompiledAccountsUB(SHANGHAI)
-    rule #precompiledAccountsUB(ECOTONE)           => #precompiledAccountsUB(CANCUN)
-    rule #precompiledAccountsUB(FJORD)             => #precompiledAccountsUB(ECOTONE)
-    rule #precompiledAccountsUB(GRANITE)           => #precompiledAccountsUB(FJORD)
-    rule #precompiledAccountsUB(HOLOCENE)          => #precompiledAccountsUB(GRANITE)
-    rule #precompiledAccountsUB(ISTHMUS)           => #precompiledAccountsUB(PRAGUE)
-
-
-    syntax Set ::= #precompiledAccountsSet    ( Schedule ) [symbol(#precompiledAccountsSet),    function, total]
-    syntax Set ::= #precompiledAccountsSetAux ( MInt{256}) [symbol(#precompiledAccountsSetAux), function, total]
- // ------------------------------------------------------------------------------------------------------------
-    rule #precompiledAccountsSet(SCHED) => #precompiledAccountsSetAux(#precompiledAccountsUB(SCHED))
-
-    rule #precompiledAccountsSetAux(N)  => .Set requires N ==MInt 0p256
-    rule #precompiledAccountsSetAux(N)  => SetItem(N) #precompiledAccountsSetAux(N -MInt 1p256) [owise, preserves-definedness]
 ```
 
 -   `ECREC` performs ECDSA public key recovery.

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
@@ -80,6 +80,10 @@ module SCHEDULE
                           | "Ghaswarmcoinbase"        | "Ghaswithdrawals"  | "Ghastransient"       | "Ghasmcopy"
                           | "Ghasbeaconroot"          | "Ghaseip6780"      | "Ghasblobbasefee"     | "Ghasblobhash"
                           | "Ghasbls12msmdiscount"    | "Ghasdelegation"   | "Gecpairinputcheck"
+
+    syntax Bool ::= #isPrecompiledAccount ( MInt{256} , Schedule ) [symbol(isPrecompiledAccount), function, total, smtlib(isPrecompiledAccount)]
+ // --------------------------------------------------------------------------------------------------------------------------------------------
+    rule #isPrecompiledAccount(_, _) => false [owise]
 ```
 
 ### Schedule Constants
@@ -219,6 +223,11 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << FRONTIER >> => false
     rule Ghasdelegation          << FRONTIER >> => false
     rule Gecpairinputcheck       << FRONTIER >> => false
+
+    rule #isPrecompiledAccount(1p256, FRONTIER) => true
+    rule #isPrecompiledAccount(2p256, FRONTIER) => true
+    rule #isPrecompiledAccount(3p256, FRONTIER) => true
+    rule #isPrecompiledAccount(4p256, FRONTIER) => true
 ```
 
 ### Homestead Schedule
@@ -337,6 +346,11 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << HOMESTEAD >> => false
     rule Ghasdelegation          << HOMESTEAD >> => false
     rule Gecpairinputcheck       << HOMESTEAD >> => false
+
+    rule #isPrecompiledAccount(1p256, HOMESTEAD) => true
+    rule #isPrecompiledAccount(2p256, HOMESTEAD) => true
+    rule #isPrecompiledAccount(3p256, HOMESTEAD) => true
+    rule #isPrecompiledAccount(4p256, HOMESTEAD) => true
 ```
 
 ### Tangerine Whistle Schedule
@@ -455,6 +469,11 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << TANGERINE_WHISTLE >> => false
     rule Ghasdelegation          << TANGERINE_WHISTLE >> => false
     rule Gecpairinputcheck       << TANGERINE_WHISTLE >> => false
+
+    rule #isPrecompiledAccount(1p256, TANGERINE_WHISTLE) => true
+    rule #isPrecompiledAccount(2p256, TANGERINE_WHISTLE) => true
+    rule #isPrecompiledAccount(3p256, TANGERINE_WHISTLE) => true
+    rule #isPrecompiledAccount(4p256, TANGERINE_WHISTLE) => true
 ```
 
 ### Spurious Dragon Schedule
@@ -573,6 +592,11 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << SPURIOUS_DRAGON >> => false
     rule Ghasdelegation          << SPURIOUS_DRAGON >> => false
     rule Gecpairinputcheck       << SPURIOUS_DRAGON >> => false
+
+    rule #isPrecompiledAccount(1p256, SPURIOUS_DRAGON) => true
+    rule #isPrecompiledAccount(2p256, SPURIOUS_DRAGON) => true
+    rule #isPrecompiledAccount(3p256, SPURIOUS_DRAGON) => true
+    rule #isPrecompiledAccount(4p256, SPURIOUS_DRAGON) => true
 ```
 
 ### Byzantium Schedule
@@ -691,6 +715,15 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << BYZANTIUM >> => false
     rule Ghasdelegation          << BYZANTIUM >> => false
     rule Gecpairinputcheck       << BYZANTIUM >> => false
+
+    rule #isPrecompiledAccount(1p256, BYZANTIUM) => true
+    rule #isPrecompiledAccount(2p256, BYZANTIUM) => true
+    rule #isPrecompiledAccount(3p256, BYZANTIUM) => true
+    rule #isPrecompiledAccount(4p256, BYZANTIUM) => true
+    rule #isPrecompiledAccount(5p256, BYZANTIUM) => true
+    rule #isPrecompiledAccount(6p256, BYZANTIUM) => true
+    rule #isPrecompiledAccount(7p256, BYZANTIUM) => true
+    rule #isPrecompiledAccount(8p256, BYZANTIUM) => true
 ```
 
 ### Constantinople Schedule
@@ -809,6 +842,15 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << CONSTANTINOPLE >> => false
     rule Ghasdelegation          << CONSTANTINOPLE >> => false
     rule Gecpairinputcheck       << CONSTANTINOPLE >> => false
+
+    rule #isPrecompiledAccount(1p256, CONSTANTINOPLE) => true
+    rule #isPrecompiledAccount(2p256, CONSTANTINOPLE) => true
+    rule #isPrecompiledAccount(3p256, CONSTANTINOPLE) => true
+    rule #isPrecompiledAccount(4p256, CONSTANTINOPLE) => true
+    rule #isPrecompiledAccount(5p256, CONSTANTINOPLE) => true
+    rule #isPrecompiledAccount(6p256, CONSTANTINOPLE) => true
+    rule #isPrecompiledAccount(7p256, CONSTANTINOPLE) => true
+    rule #isPrecompiledAccount(8p256, CONSTANTINOPLE) => true
 ```
 
 ### Petersburg Schedule
@@ -927,6 +969,15 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << PETERSBURG >> => false
     rule Ghasdelegation          << PETERSBURG >> => false
     rule Gecpairinputcheck       << PETERSBURG >> => false
+
+    rule #isPrecompiledAccount(1p256, PETERSBURG) => true
+    rule #isPrecompiledAccount(2p256, PETERSBURG) => true
+    rule #isPrecompiledAccount(3p256, PETERSBURG) => true
+    rule #isPrecompiledAccount(4p256, PETERSBURG) => true
+    rule #isPrecompiledAccount(5p256, PETERSBURG) => true
+    rule #isPrecompiledAccount(6p256, PETERSBURG) => true
+    rule #isPrecompiledAccount(7p256, PETERSBURG) => true
+    rule #isPrecompiledAccount(8p256, PETERSBURG) => true
 ```
 
 ### Istanbul Schedule
@@ -1045,6 +1096,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << ISTANBUL >> => false
     rule Ghasdelegation          << ISTANBUL >> => false
     rule Gecpairinputcheck       << ISTANBUL >> => false
+
+    rule #isPrecompiledAccount(1p256, ISTANBUL) => true
+    rule #isPrecompiledAccount(2p256, ISTANBUL) => true
+    rule #isPrecompiledAccount(3p256, ISTANBUL) => true
+    rule #isPrecompiledAccount(4p256, ISTANBUL) => true
+    rule #isPrecompiledAccount(5p256, ISTANBUL) => true
+    rule #isPrecompiledAccount(6p256, ISTANBUL) => true
+    rule #isPrecompiledAccount(7p256, ISTANBUL) => true
+    rule #isPrecompiledAccount(8p256, ISTANBUL) => true
+    rule #isPrecompiledAccount(9p256, ISTANBUL) => true
 ```
 
 ### Berlin Schedule
@@ -1163,6 +1224,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << BERLIN >> => false
     rule Ghasdelegation          << BERLIN >> => false
     rule Gecpairinputcheck       << BERLIN >> => false
+
+    rule #isPrecompiledAccount(1p256, BERLIN) => true
+    rule #isPrecompiledAccount(2p256, BERLIN) => true
+    rule #isPrecompiledAccount(3p256, BERLIN) => true
+    rule #isPrecompiledAccount(4p256, BERLIN) => true
+    rule #isPrecompiledAccount(5p256, BERLIN) => true
+    rule #isPrecompiledAccount(6p256, BERLIN) => true
+    rule #isPrecompiledAccount(7p256, BERLIN) => true
+    rule #isPrecompiledAccount(8p256, BERLIN) => true
+    rule #isPrecompiledAccount(9p256, BERLIN) => true
 ```
 
 ### London Schedule
@@ -1281,6 +1352,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << LONDON >> => false
     rule Ghasdelegation          << LONDON >> => false
     rule Gecpairinputcheck       << LONDON >> => false
+
+    rule #isPrecompiledAccount(1p256, LONDON) => true
+    rule #isPrecompiledAccount(2p256, LONDON) => true
+    rule #isPrecompiledAccount(3p256, LONDON) => true
+    rule #isPrecompiledAccount(4p256, LONDON) => true
+    rule #isPrecompiledAccount(5p256, LONDON) => true
+    rule #isPrecompiledAccount(6p256, LONDON) => true
+    rule #isPrecompiledAccount(7p256, LONDON) => true
+    rule #isPrecompiledAccount(8p256, LONDON) => true
+    rule #isPrecompiledAccount(9p256, LONDON) => true
 ```
 
 ### Merge Schedule
@@ -1399,6 +1480,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << MERGE >> => false
     rule Ghasdelegation          << MERGE >> => false
     rule Gecpairinputcheck       << MERGE >> => false
+
+    rule #isPrecompiledAccount(1p256, MERGE) => true
+    rule #isPrecompiledAccount(2p256, MERGE) => true
+    rule #isPrecompiledAccount(3p256, MERGE) => true
+    rule #isPrecompiledAccount(4p256, MERGE) => true
+    rule #isPrecompiledAccount(5p256, MERGE) => true
+    rule #isPrecompiledAccount(6p256, MERGE) => true
+    rule #isPrecompiledAccount(7p256, MERGE) => true
+    rule #isPrecompiledAccount(8p256, MERGE) => true
+    rule #isPrecompiledAccount(9p256, MERGE) => true
 ```
 
 ### Shanghai Schedule
@@ -1518,6 +1609,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << SHANGHAI >> => false
     rule Ghasdelegation          << SHANGHAI >> => false
     rule Gecpairinputcheck       << SHANGHAI >> => false
+
+    rule #isPrecompiledAccount(1p256, SHANGHAI) => true
+    rule #isPrecompiledAccount(2p256, SHANGHAI) => true
+    rule #isPrecompiledAccount(3p256, SHANGHAI) => true
+    rule #isPrecompiledAccount(4p256, SHANGHAI) => true
+    rule #isPrecompiledAccount(5p256, SHANGHAI) => true
+    rule #isPrecompiledAccount(6p256, SHANGHAI) => true
+    rule #isPrecompiledAccount(7p256, SHANGHAI) => true
+    rule #isPrecompiledAccount(8p256, SHANGHAI) => true
+    rule #isPrecompiledAccount(9p256, SHANGHAI) => true
 ```
 
 ### Cancun Schedule
@@ -1637,6 +1738,17 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << CANCUN >> => false
     rule Ghasdelegation          << CANCUN >> => false
     rule Gecpairinputcheck       << CANCUN >> => false
+
+    rule #isPrecompiledAccount(1p256, CANCUN) => true
+    rule #isPrecompiledAccount(2p256, CANCUN) => true
+    rule #isPrecompiledAccount(3p256, CANCUN) => true
+    rule #isPrecompiledAccount(4p256, CANCUN) => true
+    rule #isPrecompiledAccount(5p256, CANCUN) => true
+    rule #isPrecompiledAccount(6p256, CANCUN) => true
+    rule #isPrecompiledAccount(7p256, CANCUN) => true
+    rule #isPrecompiledAccount(8p256, CANCUN) => true
+    rule #isPrecompiledAccount(9p256, CANCUN) => true
+    rule #isPrecompiledAccount(10p256, CANCUN) => true
 ```
 
 ### Prague Schedule
@@ -1757,6 +1869,24 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << PRAGUE >> => true
     rule Ghasdelegation          << PRAGUE >> => true
     rule Gecpairinputcheck       << PRAGUE >> => false
+
+    rule #isPrecompiledAccount(1p256, PRAGUE) => true
+    rule #isPrecompiledAccount(2p256, PRAGUE) => true
+    rule #isPrecompiledAccount(3p256, PRAGUE) => true
+    rule #isPrecompiledAccount(4p256, PRAGUE) => true
+    rule #isPrecompiledAccount(5p256, PRAGUE) => true
+    rule #isPrecompiledAccount(6p256, PRAGUE) => true
+    rule #isPrecompiledAccount(7p256, PRAGUE) => true
+    rule #isPrecompiledAccount(8p256, PRAGUE) => true
+    rule #isPrecompiledAccount(9p256, PRAGUE) => true
+    rule #isPrecompiledAccount(10p256, PRAGUE) => true
+    rule #isPrecompiledAccount(11p256, PRAGUE) => true
+    rule #isPrecompiledAccount(12p256, PRAGUE) => true
+    rule #isPrecompiledAccount(13p256, PRAGUE) => true
+    rule #isPrecompiledAccount(14p256, PRAGUE) => true
+    rule #isPrecompiledAccount(15p256, PRAGUE) => true
+    rule #isPrecompiledAccount(16p256, PRAGUE) => true
+    rule #isPrecompiledAccount(17p256, PRAGUE) => true
 ```
 
 ### Bedrock Schedule
@@ -1875,6 +2005,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << BEDROCK >> => false
     rule Ghasdelegation          << BEDROCK >> => false
     rule Gecpairinputcheck       << BEDROCK >> => false
+
+    rule #isPrecompiledAccount(1p256, BEDROCK) => true
+    rule #isPrecompiledAccount(2p256, BEDROCK) => true
+    rule #isPrecompiledAccount(3p256, BEDROCK) => true
+    rule #isPrecompiledAccount(4p256, BEDROCK) => true
+    rule #isPrecompiledAccount(5p256, BEDROCK) => true
+    rule #isPrecompiledAccount(6p256, BEDROCK) => true
+    rule #isPrecompiledAccount(7p256, BEDROCK) => true
+    rule #isPrecompiledAccount(8p256, BEDROCK) => true
+    rule #isPrecompiledAccount(9p256, BEDROCK) => true
 ```
 
 ### Regolith Schedule
@@ -1993,6 +2133,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << REGOLITH >> => false
     rule Ghasdelegation          << REGOLITH >> => false
     rule Gecpairinputcheck       << REGOLITH >> => false
+
+    rule #isPrecompiledAccount(1p256, REGOLITH) => true
+    rule #isPrecompiledAccount(2p256, REGOLITH) => true
+    rule #isPrecompiledAccount(3p256, REGOLITH) => true
+    rule #isPrecompiledAccount(4p256, REGOLITH) => true
+    rule #isPrecompiledAccount(5p256, REGOLITH) => true
+    rule #isPrecompiledAccount(6p256, REGOLITH) => true
+    rule #isPrecompiledAccount(7p256, REGOLITH) => true
+    rule #isPrecompiledAccount(8p256, REGOLITH) => true
+    rule #isPrecompiledAccount(9p256, REGOLITH) => true
 ```
 
 ### Canyon Schedule
@@ -2112,6 +2262,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << CANYON >> => false
     rule Ghasdelegation          << CANYON >> => false
     rule Gecpairinputcheck       << CANYON >> => false
+
+    rule #isPrecompiledAccount(1p256, CANYON) => true
+    rule #isPrecompiledAccount(2p256, CANYON) => true
+    rule #isPrecompiledAccount(3p256, CANYON) => true
+    rule #isPrecompiledAccount(4p256, CANYON) => true
+    rule #isPrecompiledAccount(5p256, CANYON) => true
+    rule #isPrecompiledAccount(6p256, CANYON) => true
+    rule #isPrecompiledAccount(7p256, CANYON) => true
+    rule #isPrecompiledAccount(8p256, CANYON) => true
+    rule #isPrecompiledAccount(9p256, CANYON) => true
 ```
 
 ### Ecotone Schedule
@@ -2231,6 +2391,17 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << ECOTONE >> => false
     rule Ghasdelegation          << ECOTONE >> => false
     rule Gecpairinputcheck       << ECOTONE >> => false
+
+    rule #isPrecompiledAccount(1p256, ECOTONE) => true
+    rule #isPrecompiledAccount(2p256, ECOTONE) => true
+    rule #isPrecompiledAccount(3p256, ECOTONE) => true
+    rule #isPrecompiledAccount(4p256, ECOTONE) => true
+    rule #isPrecompiledAccount(5p256, ECOTONE) => true
+    rule #isPrecompiledAccount(6p256, ECOTONE) => true
+    rule #isPrecompiledAccount(7p256, ECOTONE) => true
+    rule #isPrecompiledAccount(8p256, ECOTONE) => true
+    rule #isPrecompiledAccount(9p256, ECOTONE) => true
+    rule #isPrecompiledAccount(10p256, ECOTONE) => true
 ```
 
 ### Fjord Schedule
@@ -2350,6 +2521,17 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << FJORD >> => false
     rule Ghasdelegation          << FJORD >> => false
     rule Gecpairinputcheck       << FJORD >> => false
+
+    rule #isPrecompiledAccount(1p256, FJORD) => true
+    rule #isPrecompiledAccount(2p256, FJORD) => true
+    rule #isPrecompiledAccount(3p256, FJORD) => true
+    rule #isPrecompiledAccount(4p256, FJORD) => true
+    rule #isPrecompiledAccount(5p256, FJORD) => true
+    rule #isPrecompiledAccount(6p256, FJORD) => true
+    rule #isPrecompiledAccount(7p256, FJORD) => true
+    rule #isPrecompiledAccount(8p256, FJORD) => true
+    rule #isPrecompiledAccount(9p256, FJORD) => true
+    rule #isPrecompiledAccount(10p256, FJORD) => true
 ```
 
 ### Granite Schedule
@@ -2469,6 +2651,17 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << GRANITE >> => false
     rule Ghasdelegation          << GRANITE >> => false
     rule Gecpairinputcheck       << GRANITE >> => true
+
+    rule #isPrecompiledAccount(1p256, GRANITE) => true
+    rule #isPrecompiledAccount(2p256, GRANITE) => true
+    rule #isPrecompiledAccount(3p256, GRANITE) => true
+    rule #isPrecompiledAccount(4p256, GRANITE) => true
+    rule #isPrecompiledAccount(5p256, GRANITE) => true
+    rule #isPrecompiledAccount(6p256, GRANITE) => true
+    rule #isPrecompiledAccount(7p256, GRANITE) => true
+    rule #isPrecompiledAccount(8p256, GRANITE) => true
+    rule #isPrecompiledAccount(9p256, GRANITE) => true
+    rule #isPrecompiledAccount(10p256, GRANITE) => true
 ```
 
 ### Holocene Schedule
@@ -2588,6 +2781,17 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << HOLOCENE >> => false
     rule Ghasdelegation          << HOLOCENE >> => false
     rule Gecpairinputcheck       << HOLOCENE >> => true
+
+    rule #isPrecompiledAccount(1p256, HOLOCENE) => true
+    rule #isPrecompiledAccount(2p256, HOLOCENE) => true
+    rule #isPrecompiledAccount(3p256, HOLOCENE) => true
+    rule #isPrecompiledAccount(4p256, HOLOCENE) => true
+    rule #isPrecompiledAccount(5p256, HOLOCENE) => true
+    rule #isPrecompiledAccount(6p256, HOLOCENE) => true
+    rule #isPrecompiledAccount(7p256, HOLOCENE) => true
+    rule #isPrecompiledAccount(8p256, HOLOCENE) => true
+    rule #isPrecompiledAccount(9p256, HOLOCENE) => true
+    rule #isPrecompiledAccount(10p256, HOLOCENE) => true
 ```
 
 ### Isthmus Schedule
@@ -2708,6 +2912,24 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule Ghasbls12msmdiscount    << ISTHMUS >> => true
     rule Ghasdelegation          << ISTHMUS >> => true
     rule Gecpairinputcheck       << ISTHMUS >> => true
+
+    rule #isPrecompiledAccount(1p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(2p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(3p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(4p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(5p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(6p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(7p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(8p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(9p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(10p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(11p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(12p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(13p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(14p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(15p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(16p256, ISTHMUS) => true
+    rule #isPrecompiledAccount(17p256, ISTHMUS) => true
 
 endmodule
 ```


### PR DESCRIPTION
This PR addresses issue Pi-Squared-Inc/pi2/issues/2837

- The proposed `syntax OpCode ::= getPrecompile(MInt)` already exists, it is this one:
https://github.com/Pi-Squared-Inc/evm-semantics/blob/f4bf49bb7415599fbf2073266d95b6c9b709c72e/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md?plain=1#L1244
We will extend it as new precompiles are added, e.g., 
```
    rule #precompiled(256p256) => P256VERIFY
```
- The proposed `syntax Bool ::= isPrecompile(MInt, Schedule)`, that should check whether a MInt is an address of a precompiled contract in a Schedule corresponds to the existing `syntax Bool ::= #isPrecompiledAccount ( MInt{256} , Schedule )`. I replaced the implementation according to our discussion: It is defined for all pairs of `MInt`, `Schedule` for which it is true, and false otherwise. For example, we will include the following rules
```
rule #isPrecompiledAccount(256p256, FJORD) => true
rule #isPrecompiledAccount(256p256, GRANITE) => true
rule #isPrecompiledAccount(256p256, HOLOCENE) => true
rule #isPrecompiledAccount(256p256, ISTHMUS) => true
```
to enable `P256VERIFY` on schedules `FJORD` onwards.

We also remove `#precompiledAccountsSet`, since
- I found no uses of it
- it used `#precompiledAccountsUB` which was no longer accurate and also deleted
If we need it, let me know and I will redefine it, using a rule per schedule.